### PR TITLE
Add streaming server functions

### DIFF
--- a/examples/astro/package.json
+++ b/examples/astro/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "astro": "^3.2.3",
     "autoprefixer": "^10.4.16",
-    "eslint": "^8.51.0",
+    "eslint": "^8.54.0",
     "eslint-config-lxsmnsyc": "^0.6.5",
     "postcss": "^8.4.31",
     "typescript": "^5.2.2",

--- a/examples/astro/package.json
+++ b/examples/astro/package.json
@@ -14,7 +14,7 @@
     "eslint": "^8.54.0",
     "eslint-config-lxsmnsyc": "^0.6.5",
     "postcss": "^8.4.31",
-    "typescript": "^5.2.2",
+    "typescript": "^5.3.2",
     "unplugin-thaler": "0.7.2"
   },
   "dependencies": {

--- a/examples/astro/src/components/Example.tsx
+++ b/examples/astro/src/components/Example.tsx
@@ -1,8 +1,9 @@
 import type { JSX } from 'solid-js';
 import {
-  createResource, createSignal, onMount, Suspense, 
+  createResource, createSignal, onMount, Suspense,
 } from 'solid-js';
 import { fn$ } from 'thaler';
+import { debounce } from 'thaler/utils';
 
 const sleep = async <T, >(value: T, ms: number): Promise<T> => new Promise<T>((res) => {
   setTimeout(res, ms, value);
@@ -13,11 +14,16 @@ export default function Example(): JSX.Element {
 
   const prefix = 'Server Count';
 
-  const serverCount = fn$(async (value: number) => {
-    const delayed = await sleep(value, 1000);
-    console.log('Received', delayed);
-    return `${prefix}: ${delayed}`;
-  });
+  const serverCount = debounce(
+    fn$(async (value: number) => {
+      const delayed = await sleep(value, 1000);
+      console.log('Received', delayed);
+      return `${prefix}: ${delayed}`;
+    }),
+    {
+      key: () => 'example',
+    },
+  );
 
   const [data] = createResource(state, async (value) => serverCount(value));
 

--- a/examples/astro/src/components/Example.tsx
+++ b/examples/astro/src/components/Example.tsx
@@ -5,9 +5,11 @@ import {
 import { fn$ } from 'thaler';
 import { debounce } from 'thaler/utils';
 
-const sleep = async <T, >(value: T, ms: number): Promise<T> => new Promise<T>((res) => {
-  setTimeout(res, ms, value);
-});
+async function sleep<T>(value: T, ms: number): Promise<T> {
+  return new Promise<T>((res) => {
+    setTimeout(res, ms, value);
+  });
+}
 
 export default function Example(): JSX.Element {
   const [state, setState] = createSignal(0);

--- a/examples/astro/src/components/Example.tsx
+++ b/examples/astro/src/components/Example.tsx
@@ -1,29 +1,46 @@
-import { createResource, createSignal, Suspense } from 'solid-js';
+import type { JSX } from 'solid-js';
+import {
+  createResource, createSignal, onMount, Suspense, 
+} from 'solid-js';
 import { fn$ } from 'thaler';
-import { debounce } from 'thaler/utils';
 
-const sleep = (ms: number) => new Promise((res) => {
-  setTimeout(res, ms, true);
+const sleep = async <T, >(value: T, ms: number): Promise<T> => new Promise<T>((res) => {
+  setTimeout(res, ms, value);
 });
 
-export default function Example() {
+export default function Example(): JSX.Element {
   const [state, setState] = createSignal(0);
 
   const prefix = 'Server Count';
 
-  const serverCount = debounce(fn$(async (value: number) => {
-    await sleep(1000);
-    console.log('Received', value);
-    return `${prefix}: ${value}`;
-  }), {
-    key: () => 'sleep',
+  const serverCount = fn$(async (value: number) => {
+    const delayed = await sleep(value, 1000);
+    console.log('Received', delayed);
+    return `${prefix}: ${delayed}`;
   });
 
-  const [data] = createResource(state, (value) => serverCount(value));
+  const [data] = createResource(state, async (value) => serverCount(value));
 
-  function increment() {
+  function increment(): void {
     setState((c) => c + 1);
   }
+
+  const example = fn$(async function* foo(items: string[]) {
+    for (const item of items) {
+      yield sleep(item, 1000);
+    }
+  });
+
+  onMount(() => {
+    (async (): Promise<void> => {
+      const iterator = await example(['foo', 'bar', 'baz']);
+      for await (const value of iterator) {
+        console.log('Received: ', value);
+      }
+    })().catch(() => {
+      //
+    });
+  });
 
   return (
     <>

--- a/examples/solidstart/package.json
+++ b/examples/solidstart/package.json
@@ -13,7 +13,7 @@
     "esbuild": "^0.19.4",
     "postcss": "^8.4.25",
     "solid-start-node": "^0.3.6",
-    "typescript": "^5.2.2",
+    "typescript": "^5.3.2",
     "unplugin-thaler": "0.7.2",
     "vite": "^4.4.11"
   },

--- a/examples/sveltekit/package.json
+++ b/examples/sveltekit/package.json
@@ -22,7 +22,7 @@
 		"svelte": "^4.0.5",
 		"svelte-check": "^3.5.2",
 		"tslib": "^2.6.2",
-		"typescript": "^5.2.2",
+		"typescript": "^5.3.2",
 		"unplugin-thaler": "0.7.2",
 		"vite": "^4.4.11"
 	},

--- a/examples/sveltekit/package.json
+++ b/examples/sveltekit/package.json
@@ -17,7 +17,7 @@
 		"@sveltejs/adapter-auto": "^2.1.0",
 		"@sveltejs/kit": "^1.25.1",
 		"@types/cookie": "^0.5.1",
-		"eslint": "^8.51.0",
+		"eslint": "^8.54.0",
 		"eslint-config-lxsmnsyc": "^0.6.5",
 		"svelte": "^4.0.5",
 		"svelte-check": "^3.5.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
     "eslint": "^8.54.0",
     "eslint-config-lxsmnsyc": "^0.6.5",
     "lerna": "^7.4.2",
-    "typescript": "^5.2.2"
+    "typescript": "^5.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "examples/*"
   ],
   "devDependencies": {
-    "eslint": "^8.51.0",
+    "eslint": "^8.54.0",
     "eslint-config-lxsmnsyc": "^0.6.5",
-    "lerna": "^7.3.0",
+    "lerna": "^7.4.2",
     "typescript": "^5.2.2"
   }
 }

--- a/packages/thaler/.eslintrc.cjs
+++ b/packages/thaler/.eslintrc.cjs
@@ -12,12 +12,7 @@ module.exports = {
       "error", {
         "devDependencies": ["**/*.test.ts"]
       }
-    ],
-    "no-plusplus": "off",
-    "no-continue": "off",
-    "no-param-reassign": "off",
-    "no-restricted-syntax": "off",
-    "no-bitwise": "off",
+    ]
     "@typescript-eslint/no-unsafe-argument": "off",
     "@typescript-eslint/no-unsafe-assignment": "off",
     "@typescript-eslint/no-unsafe-return": "off"

--- a/packages/thaler/compiler/get-foreign-bindings.ts
+++ b/packages/thaler/compiler/get-foreign-bindings.ts
@@ -76,9 +76,14 @@ export default function getForeignBindings(path: babel.NodePath): t.Identifier[]
         case 'let':
         case 'var':
         case 'param':
+        case 'local':
         case 'hoisted': {
-          const blockParent = binding.path.scope.getBlockParent();
+          let blockParent = binding.path.scope.getBlockParent();
           const programParent = binding.path.scope.getProgramParent();
+
+          if (blockParent.path === binding.path) {
+            blockParent = blockParent.parent;
+          }
 
           // We don't need top-level declarations
           if (blockParent !== programParent) {

--- a/packages/thaler/package.json
+++ b/packages/thaler/package.json
@@ -17,7 +17,7 @@
     "@types/babel__core": "^7.20.3",
     "@types/babel__traverse": "^7.20.3",
     "@types/node": "^20.8.7",
-    "eslint": "^8.51.0",
+    "eslint": "^8.54.0",
     "eslint-config-lxsmnsyc": "^0.6.5",
     "pridepack": "2.5.1",
     "tslib": "^2.6.2",
@@ -29,7 +29,7 @@
     "@babel/helper-module-imports": "^7.22.15",
     "@babel/traverse": "^7.23.2",
     "@babel/types": "^7.23.0",
-    "seroval": "^0.12.0"
+    "seroval": "^0.13.0"
   },
   "scripts": {
     "prepublishOnly": "pridepack clean && pridepack build",

--- a/packages/thaler/package.json
+++ b/packages/thaler/package.json
@@ -21,7 +21,7 @@
     "eslint-config-lxsmnsyc": "^0.6.5",
     "pridepack": "2.5.1",
     "tslib": "^2.6.2",
-    "typescript": "^5.2.2",
+    "typescript": "^5.3.2",
     "vitest": "^0.34.6"
   },
   "dependencies": {
@@ -29,7 +29,7 @@
     "@babel/helper-module-imports": "^7.22.15",
     "@babel/traverse": "^7.23.2",
     "@babel/types": "^7.23.0",
-    "seroval": "^0.13.0"
+    "seroval": "^0.13.2"
   },
   "scripts": {
     "prepublishOnly": "pridepack clean && pridepack build",

--- a/packages/thaler/server/index.ts
+++ b/packages/thaler/server/index.ts
@@ -1,7 +1,7 @@
 import {
   createReference,
   fromJSON,
-  serializeAsync,
+  toCrossJSONStream,
   toJSONAsync,
 } from 'seroval';
 import type {
@@ -104,6 +104,26 @@ export function $$action<T extends ThalerPostParam, R>(
   const reg: ActionHandlerRegistration<T, R> = ['action', id, callback];
   REGISTRATIONS.set(id, reg);
   return reg;
+}
+
+function serializeToStream<T>(value: T): ReadableStream {
+  return new ReadableStream({
+    start(controller): void {
+      toCrossJSONStream(value, {
+        onParse(node) {
+          controller.enqueue(
+            new TextEncoder().encode(`${JSON.stringify(node)}\n`),
+          );
+        },
+        onDone() {
+          controller.close();
+        },
+        onError(error) {
+          controller.error(error);
+        },
+      });
+    },
+  });
 }
 
 function createResponseInit(): ThalerResponseInit {
@@ -324,10 +344,9 @@ export async function handleRequest(request: Request): Promise<Response | undefi
               response,
             }),
           );
-          const serialized = await serializeAsync(result);
           const headers = new Headers(response.headers);
-          headers.set('Content-Type', 'text/plain');
-          return new Response(serialized, {
+          headers.set('Content-Type', 'application/json');
+          return new Response(serializeToStream(result), {
             headers,
             status: response.status,
             statusText: response.statusText,
@@ -337,10 +356,9 @@ export async function handleRequest(request: Request): Promise<Response | undefi
           const value = fromJSON(await request.json());
           const response = createResponseInit();
           const result = await callback(value, { request, response });
-          const serialized = await serializeAsync(result);
           const headers = new Headers(response.headers);
           headers.set('Content-Type', 'text/plain');
-          return new Response(serialized, {
+          return new Response(serializeToStream(result), {
             headers,
             status: response.status,
             statusText: response.statusText,
@@ -350,10 +368,9 @@ export async function handleRequest(request: Request): Promise<Response | undefi
           const value = fromURLSearchParams(url.searchParams);
           const response = createResponseInit();
           const result = await callback(value, { request, response });
-          const serialized = await serializeAsync(result);
           const headers = new Headers(response.headers);
           headers.set('Content-Type', 'text/plain');
-          return new Response(serialized, {
+          return new Response(serializeToStream(result), {
             headers,
             status: response.status,
             statusText: response.statusText,
@@ -363,10 +380,9 @@ export async function handleRequest(request: Request): Promise<Response | undefi
           const value = fromFormData(await request.formData());
           const response = createResponseInit();
           const result = await callback(value, { request, response });
-          const serialized = await serializeAsync(result);
           const headers = new Headers(response.headers);
           headers.set('Content-Type', 'text/plain');
-          return new Response(serialized, {
+          return new Response(serializeToStream(result), {
             headers,
             status: response.status,
             statusText: response.statusText,
@@ -378,7 +394,7 @@ export async function handleRequest(request: Request): Promise<Response | undefi
     } catch (error) {
       if (import.meta.env.DEV) {
         console.error(error);
-        return new Response(await serializeAsync(error), {
+        return new Response(serializeToStream(error), {
           status: 500,
         });
       }

--- a/packages/thaler/server/index.ts
+++ b/packages/thaler/server/index.ts
@@ -129,7 +129,7 @@ function serializeToStream<T>(value: T): ReadableStream {
 function createResponseInit(): ThalerResponseInit {
   return {
     headers: new Headers({
-      'Content-Type': 'text/plain',
+      'Content-Type': 'application/json',
     }),
     status: 200,
     statusText: 'OK',
@@ -357,7 +357,7 @@ export async function handleRequest(request: Request): Promise<Response | undefi
           const response = createResponseInit();
           const result = await callback(value, { request, response });
           const headers = new Headers(response.headers);
-          headers.set('Content-Type', 'text/plain');
+          headers.set('Content-Type', 'application/json');
           return new Response(serializeToStream(result), {
             headers,
             status: response.status,
@@ -369,7 +369,7 @@ export async function handleRequest(request: Request): Promise<Response | undefi
           const response = createResponseInit();
           const result = await callback(value, { request, response });
           const headers = new Headers(response.headers);
-          headers.set('Content-Type', 'text/plain');
+          headers.set('Content-Type', 'application/json');
           return new Response(serializeToStream(result), {
             headers,
             status: response.status,
@@ -381,7 +381,7 @@ export async function handleRequest(request: Request): Promise<Response | undefi
           const response = createResponseInit();
           const result = await callback(value, { request, response });
           const headers = new Headers(response.headers);
-          headers.set('Content-Type', 'text/plain');
+          headers.set('Content-Type', 'application/json');
           return new Response(serializeToStream(result), {
             headers,
             status: response.status,

--- a/packages/thaler/shared/types.ts
+++ b/packages/thaler/shared/types.ts
@@ -71,8 +71,8 @@ export interface ThalerGetFunction<P extends ThalerGetParam> extends ThalerBaseF
 export type ThalerFunctionInit = Omit<RequestInit, 'method' | 'body'>;
 
 export interface ThalerFunction<T, R> extends ThalerBaseFunction {
-  type: 'fn';
   (value: T, init?: ThalerFunctionInit): Promise<R>;
+  type: 'fn';
 }
 
 export interface ThalerPureFunction<T, R> extends ThalerBaseFunction {

--- a/packages/thaler/utils/index.ts
+++ b/packages/thaler/utils/index.ts
@@ -35,10 +35,10 @@ function createDeferred<T>(): Deferred<T> {
       resolve = res;
       reject = rej;
     }),
-    resolve(value) {
+    resolve(value): void {
       resolve(value);
     },
-    reject(value) {
+    reject(value): void {
       reject(value);
     },
   };
@@ -64,7 +64,11 @@ export function debounce<T extends AsyncFunction>(
 ): T {
   const cache = new Map<string, DebounceData<ReturnType<T>>>();
 
-  function resolveData(current: DebounceData<ReturnType<T>>, key: string, args: Parameters<T>) {
+  function resolveData(
+    current: DebounceData<ReturnType<T>>,
+    key: string,
+    args: Parameters<T>,
+  ): void {
     const instance = current.timeout;
     try {
       callback.apply(callback, args).then(
@@ -95,14 +99,18 @@ export function debounce<T extends AsyncFunction>(
     if (current) {
       clearTimeout(current.timeout);
       current.timeout = setTimeout(
-        () => resolveData(current!, key, args),
+        () => {
+          resolveData(current!, key, args);
+        },
         options.timeout || DEFAULT_DEBOUNCE_TIMEOUT,
       );
     } else {
       const record: DebounceData<ReturnType<T>> = {
         deferred: createDeferred(),
         timeout: setTimeout(
-          () => resolveData(record, key, args),
+          () => {
+            resolveData(record, key, args);
+          },
           options.timeout || DEFAULT_DEBOUNCE_TIMEOUT,
         ),
       };
@@ -127,7 +135,11 @@ export function throttle<T extends AsyncFunction>(
 ): T {
   const cache = new Map<string, ThrottleData<ReturnType<T>>>();
 
-  function resolveData(current: ThrottleData<ReturnType<T>>, key: string, args: Parameters<T>) {
+  function resolveData(
+    current: ThrottleData<ReturnType<T>>,
+    key: string,
+    args: Parameters<T>,
+  ): void {
     try {
       callback.apply(callback, args).then(
         (value) => {
@@ -180,9 +192,9 @@ export function retry<T extends AsyncFunction>(
   function resolveData(
     deferred: Deferred<ReturnType<T>>,
     args: Parameters<T>,
-  ) {
-    function backoff(time: number, count: number) {
-      function handleError(reason: unknown) {
+  ): void {
+    function backoff(time: number, count: number): void {
+      function handleError(reason: unknown): void {
         if (opts.count <= count) {
           deferred.reject(reason);
         } else {

--- a/packages/thaler/utils/index.ts
+++ b/packages/thaler/utils/index.ts
@@ -44,8 +44,6 @@ function createDeferred<T>(): Deferred<T> {
   };
 }
 
-export type AsyncFunction = (...args: unknown[]) => Promise<unknown>;
-
 const DEFAULT_DEBOUNCE_TIMEOUT = 250;
 
 export interface DebounceOptions<T extends any[]> {
@@ -58,7 +56,7 @@ interface DebounceData<R> {
   timeout: ReturnType<typeof setTimeout>;
 }
 
-export function debounce<T extends AsyncFunction>(
+export function debounce<T extends ((...args: any[]) => Promise<any>)>(
   callback: T,
   options: DebounceOptions<Parameters<T>>,
 ): T {
@@ -129,7 +127,7 @@ interface ThrottleData<R> {
   deferred: Deferred<R>;
 }
 
-export function throttle<T extends AsyncFunction>(
+export function throttle<T extends ((...args: any[]) => Promise<any>)>(
   callback: T,
   options: ThrottleOptions<Parameters<T>>,
 ): T {
@@ -181,7 +179,7 @@ const DEFAULT_RETRY_COUNT = 10;
 const DEFAULT_RETRY_INTERVAL = 5000;
 const INITIAL_RETRY_INTERVAL = 10;
 
-export function retry<T extends AsyncFunction>(
+export function retry<T extends ((...args: any[]) => Promise<any>)>(
   callback: T,
   options: RetryOptions,
 ): T {
@@ -233,7 +231,7 @@ export function retry<T extends AsyncFunction>(
   }) as unknown as T;
 }
 
-export function timeout<T extends AsyncFunction>(
+export function timeout<T extends ((...args: any[]) => Promise<any>)>(
   callback: T,
   ms: number,
 ): T {

--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -35,7 +35,7 @@
     "pridepack": "2.5.1",
     "thaler": "0.7.2",
     "tslib": "^2.6.2",
-    "typescript": "^5.2.2"
+    "typescript": "^5.3.2"
   },
   "peerDependencies": {
     "thaler": ">=0.6.0"

--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -30,7 +30,7 @@
   "name": "unplugin-thaler",
   "devDependencies": {
     "@types/node": "^20.8.7",
-    "eslint": "^8.51.0",
+    "eslint": "^8.54.0",
     "eslint-config-lxsmnsyc": "^0.6.5",
     "pridepack": "2.5.1",
     "thaler": "0.7.2",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -34,7 +34,7 @@
     "eslint-config-lxsmnsyc": "^0.6.5",
     "pridepack": "2.5.1",
     "tslib": "^2.6.2",
-    "typescript": "^5.2.2",
+    "typescript": "^5.3.2",
     "vite": "^5.0.0"
   },
   "dependencies": {

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -30,18 +30,18 @@
   "name": "vite-plugin-thaler",
   "devDependencies": {
     "@types/node": "^20.8.7",
-    "eslint": "^8.51.0",
+    "eslint": "^8.54.0",
     "eslint-config-lxsmnsyc": "^0.6.5",
     "pridepack": "2.5.1",
     "tslib": "^2.6.2",
     "typescript": "^5.2.2",
-    "vite": "^4.4.11"
+    "vite": "^5.0.0"
   },
   "dependencies": {
     "unplugin-thaler": "0.7.2"
   },
   "peerDependencies": {
-    "vite": "^3 || ^4"
+    "vite": "^3 || ^4 || ^5"
   },
   "scripts": {
     "prepublish": "pridepack clean && pridepack build",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,14 +9,14 @@ importers:
   .:
     devDependencies:
       eslint:
-        specifier: ^8.51.0
-        version: 8.51.0
+        specifier: ^8.54.0
+        version: 8.54.0
       eslint-config-lxsmnsyc:
         specifier: ^0.6.5
-        version: 0.6.5(eslint@8.51.0)(typescript@5.2.2)
+        version: 0.6.5(eslint@8.54.0)(typescript@5.2.2)
       lerna:
-        specifier: ^7.3.0
-        version: 7.3.0
+        specifier: ^7.4.2
+        version: 7.4.2
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
@@ -49,11 +49,11 @@ importers:
         specifier: ^10.4.16
         version: 10.4.16(postcss@8.4.31)
       eslint:
-        specifier: ^8.51.0
-        version: 8.51.0
+        specifier: ^8.54.0
+        version: 8.54.0
       eslint-config-lxsmnsyc:
         specifier: ^0.6.5
-        version: 0.6.5(eslint@8.51.0)(typescript@5.2.2)
+        version: 0.6.5(eslint@8.54.0)(typescript@5.2.2)
       postcss:
         specifier: ^8.4.31
         version: 8.4.31
@@ -123,11 +123,11 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       eslint:
-        specifier: ^8.51.0
-        version: 8.51.0
+        specifier: ^8.54.0
+        version: 8.54.0
       eslint-config-lxsmnsyc:
         specifier: ^0.6.5
-        version: 0.6.5(eslint@8.51.0)(typescript@5.2.2)
+        version: 0.6.5(eslint@8.54.0)(typescript@5.2.2)
       svelte:
         specifier: ^4.0.5
         version: 4.0.5
@@ -162,8 +162,8 @@ importers:
         specifier: ^7.23.0
         version: 7.23.0
       seroval:
-        specifier: ^0.12.0
-        version: 0.12.0
+        specifier: ^0.13.0
+        version: 0.13.0
     devDependencies:
       '@types/babel__core':
         specifier: ^7.20.3
@@ -175,14 +175,14 @@ importers:
         specifier: ^20.8.7
         version: 20.8.7
       eslint:
-        specifier: ^8.51.0
-        version: 8.51.0
+        specifier: ^8.54.0
+        version: 8.54.0
       eslint-config-lxsmnsyc:
         specifier: ^0.6.5
-        version: 0.6.5(eslint@8.51.0)(typescript@5.2.2)
+        version: 0.6.5(eslint@8.54.0)(typescript@5.2.2)
       pridepack:
         specifier: 2.5.1
-        version: 2.5.1(eslint@8.51.0)(tslib@2.6.2)(typescript@5.2.2)
+        version: 2.5.1(eslint@8.54.0)(tslib@2.6.2)(typescript@5.2.2)
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -206,14 +206,14 @@ importers:
         specifier: ^20.8.7
         version: 20.8.7
       eslint:
-        specifier: ^8.51.0
-        version: 8.51.0
+        specifier: ^8.54.0
+        version: 8.54.0
       eslint-config-lxsmnsyc:
         specifier: ^0.6.5
-        version: 0.6.5(eslint@8.51.0)(typescript@5.2.2)
+        version: 0.6.5(eslint@8.54.0)(typescript@5.2.2)
       pridepack:
         specifier: 2.5.1
-        version: 2.5.1(eslint@8.51.0)(tslib@2.6.2)(typescript@5.2.2)
+        version: 2.5.1(eslint@8.54.0)(tslib@2.6.2)(typescript@5.2.2)
       thaler:
         specifier: 0.7.2
         version: link:../thaler
@@ -234,14 +234,14 @@ importers:
         specifier: ^20.8.7
         version: 20.8.7
       eslint:
-        specifier: ^8.51.0
-        version: 8.51.0
+        specifier: ^8.54.0
+        version: 8.54.0
       eslint-config-lxsmnsyc:
         specifier: ^0.6.5
-        version: 0.6.5(eslint@8.51.0)(typescript@5.2.2)
+        version: 0.6.5(eslint@8.54.0)(typescript@5.2.2)
       pridepack:
         specifier: 2.5.1
-        version: 2.5.1(eslint@8.51.0)(tslib@2.6.2)(typescript@5.2.2)
+        version: 2.5.1(eslint@8.54.0)(tslib@2.6.2)(typescript@5.2.2)
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
@@ -249,8 +249,8 @@ importers:
         specifier: ^5.2.2
         version: 5.2.2
       vite:
-        specifier: ^4.4.11
-        version: 4.4.11(@types/node@20.8.7)
+        specifier: ^5.0.0
+        version: 5.0.0(@types/node@20.8.7)
 
 packages:
 
@@ -418,7 +418,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/eslint-parser@7.19.1(@babel/core@7.23.2)(eslint@8.51.0):
+  /@babel/eslint-parser@7.19.1(@babel/core@7.23.2)(eslint@8.54.0):
     resolution: {integrity: sha512-AqNf2QWt1rtu2/1rLswy6CDP7H9Oh3mMhk177Y67Rg8d7RD9WfOLLv8CGn6tisFvS2htm86yIe1yLF6I1UDaGQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
     peerDependencies:
@@ -427,7 +427,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.2
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 8.51.0
+      eslint: 8.54.0
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
     dev: true
@@ -2296,13 +2296,13 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@eslint-community/eslint-utils@4.4.0(eslint@8.51.0):
+  /@eslint-community/eslint-utils@4.4.0(eslint@8.54.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
     dependencies:
-      eslint: 8.51.0
+      eslint: 8.54.0
       eslint-visitor-keys: 3.4.3
     dev: true
 
@@ -2316,8 +2316,8 @@ packages:
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     dev: true
 
-  /@eslint/eslintrc@2.1.2:
-    resolution: {integrity: sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==}
+  /@eslint/eslintrc@2.1.3:
+    resolution: {integrity: sha512-yZzuIG+jnVu6hNSzFEN07e8BxF3uAzYtQb6uDkaYZLo6oYZDCq454c5kB8zxnzfCYyP4MIuyBn10L0DqwujTmA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
@@ -2333,8 +2333,8 @@ packages:
       - supports-color
     dev: true
 
-  /@eslint/js@8.51.0:
-    resolution: {integrity: sha512-HxjQ8Qn+4SI3/AFv6sOrDB+g6PpUTDwSJiQqOrnneEk8L71161srI9gjzzZvYVbzHiVg/BvcH95+cK/zfIt4pg==}
+  /@eslint/js@8.54.0:
+    resolution: {integrity: sha512-ut5V+D+fOoWPgGGNj83GGjnntO39xDy6DWxO0wb7Jp3DcMX0TfIqdzHF85VTQkerdyGmuuMD9AKAo5KiNlf/AQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
@@ -2354,11 +2354,11 @@ packages:
     dependencies:
       '@hapi/hoek': 9.3.0
 
-  /@humanwhocodes/config-array@0.11.11:
-    resolution: {integrity: sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==}
+  /@humanwhocodes/config-array@0.11.13:
+    resolution: {integrity: sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==}
     engines: {node: '>=10.10.0'}
     dependencies:
-      '@humanwhocodes/object-schema': 1.2.1
+      '@humanwhocodes/object-schema': 2.0.1
       debug: 4.3.4
       minimatch: 3.1.2
     transitivePeerDependencies:
@@ -2370,8 +2370,8 @@ packages:
     engines: {node: '>=12.22'}
     dev: true
 
-  /@humanwhocodes/object-schema@1.2.1:
-    resolution: {integrity: sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==}
+  /@humanwhocodes/object-schema@2.0.1:
+    resolution: {integrity: sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==}
     dev: true
 
   /@hutson/parse-repository-url@3.0.2:
@@ -2432,20 +2432,20 @@ packages:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
 
-  /@lerna/child-process@7.3.0:
-    resolution: {integrity: sha512-rA+fGUo2j/LEq6w1w8s6oVikLbJTWoIDVpYMc7bUCtwDOUuZKMQiRtjmpavY3fTm7ltu42f4AKflc2A70K4wvA==}
-    engines: {node: ^14.17.0 || >=16.0.0}
+  /@lerna/child-process@7.4.2:
+    resolution: {integrity: sha512-je+kkrfcvPcwL5Tg8JRENRqlbzjdlZXyaR88UcnCdNW0AJ1jX9IfHRys1X7AwSroU2ug8ESNC+suoBw1vX833Q==}
+    engines: {node: '>=16.0.0'}
     dependencies:
       chalk: 4.1.2
       execa: 5.1.1
       strong-log-transformer: 2.1.0
     dev: true
 
-  /@lerna/create@7.3.0:
-    resolution: {integrity: sha512-fjgiKjg9VXwQ4ZKKsrXICEKRiC3yo6+FprR0mc55uz0s5e9xupoSGLobUTTBdE7ncNB3ibqml8dfaAn/+ESajQ==}
-    engines: {node: ^14.17.0 || >=16.0.0}
+  /@lerna/create@7.4.2:
+    resolution: {integrity: sha512-1wplFbQ52K8E/unnqB0Tq39Z4e+NEoNrpovEnl6GpsTUrC6WDp8+w0Le2uCBV0hXyemxChduCkLz4/y1H1wTeg==}
+    engines: {node: '>=16.0.0'}
     dependencies:
-      '@lerna/child-process': 7.3.0
+      '@lerna/child-process': 7.4.2
       '@npmcli/run-script': 6.0.2
       '@nx/devkit': 16.10.0(nx@16.10.0)
       '@octokit/plugin-enterprise-rest': 6.0.1
@@ -2983,6 +2983,102 @@ packages:
       picomatch: 2.3.1
       rollup: 3.29.4
 
+  /@rollup/rollup-android-arm-eabi@4.5.0:
+    resolution: {integrity: sha512-OINaBGY+Wc++U0rdr7BLuFClxcoWaVW3vQYqmQq6B3bqQ/2olkaoz+K8+af/Mmka/C2yN5j+L9scBkv4BtKsDA==}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-android-arm64@4.5.0:
+    resolution: {integrity: sha512-UdMf1pOQc4ZmUA/NTmKhgJTBimbSKnhPS2zJqucqFyBRFPnPDtwA8MzrGNTjDeQbIAWfpJVAlxejw+/lQyBK/w==}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-darwin-arm64@4.5.0:
+    resolution: {integrity: sha512-L0/CA5p/idVKI+c9PcAPGorH6CwXn6+J0Ys7Gg1axCbTPgI8MeMlhA6fLM9fK+ssFhqogMHFC8HDvZuetOii7w==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-darwin-x64@4.5.0:
+    resolution: {integrity: sha512-QZCbVqU26mNlLn8zi/XDDquNmvcr4ON5FYAHQQsyhrHx8q+sQi/6xduoznYXwk/KmKIXG5dLfR0CvY+NAWpFYQ==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm-gnueabihf@4.5.0:
+    resolution: {integrity: sha512-VpSQ+xm93AeV33QbYslgf44wc5eJGYfYitlQzAi3OObu9iwrGXEnmu5S3ilkqE3Pr/FkgOiJKV/2p0ewf4Hrtg==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-gnu@4.5.0:
+    resolution: {integrity: sha512-OrEyIfpxSsMal44JpEVx9AEcGpdBQG1ZuWISAanaQTSMeStBW+oHWwOkoqR54bw3x8heP8gBOyoJiGg+fLY8qQ==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-arm64-musl@4.5.0:
+    resolution: {integrity: sha512-1H7wBbQuE6igQdxMSTjtFfD+DGAudcYWhp106z/9zBA8OQhsJRnemO4XGavdzHpGhRtRxbgmUGdO3YQgrWf2RA==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-gnu@4.5.0:
+    resolution: {integrity: sha512-FVyFI13tXw5aE65sZdBpNjPVIi4Q5mARnL/39UIkxvSgRAIqCo5sCpCELk0JtXHGee2owZz5aNLbWNfBHzr71Q==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-x64-musl@4.5.0:
+    resolution: {integrity: sha512-eBPYl2sLpH/o8qbSz6vPwWlDyThnQjJfcDOGFbNjmjb44XKC1F5dQfakOsADRVrXCNzM6ZsSIPDG5dc6HHLNFg==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-arm64-msvc@4.5.0:
+    resolution: {integrity: sha512-xaOHIfLOZypoQ5U2I6rEaugS4IYtTgP030xzvrBf5js7p9WI9wik07iHmsKaej8Z83ZDxN5GyypfoyKV5O5TJA==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-ia32-msvc@4.5.0:
+    resolution: {integrity: sha512-Al6quztQUrHwcOoU2TuFblUQ5L+/AmPBXFR6dUvyo4nRj2yQRK0WIUaGMF/uwKulvRcXkpHe3k9A8Vf93VDktA==}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-win32-x64-msvc@4.5.0:
+    resolution: {integrity: sha512-8kdW+brNhI/NzJ4fxDufuJUjepzINqJKLGHuxyAtpPG9bMbn8P5mtaCcbOm0EzLJ+atg+kF9dwg8jpclkVqx5w==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@sideway/address@4.1.4:
     resolution: {integrity: sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==}
     dependencies:
@@ -3244,7 +3340,7 @@ packages:
   /@types/unist@3.0.0:
     resolution: {integrity: sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w==}
 
-  /@typescript-eslint/eslint-plugin@5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.51.0)(typescript@5.2.2):
+  /@typescript-eslint/eslint-plugin@5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.54.0)(typescript@5.2.2):
     resolution: {integrity: sha512-sXtOgJNEuRU5RLwPUb1jxtToZbgvq3M6FPpY4QENxoOggK+UpTxUBpj6tD8+Qh2g46Pi9We87E+eHnUw8YcGsw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3256,12 +3352,12 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.4.0
-      '@typescript-eslint/parser': 5.59.6(eslint@8.51.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 5.59.6(eslint@8.54.0)(typescript@5.2.2)
       '@typescript-eslint/scope-manager': 5.59.6
-      '@typescript-eslint/type-utils': 5.59.6(eslint@8.51.0)(typescript@5.2.2)
-      '@typescript-eslint/utils': 5.59.6(eslint@8.51.0)(typescript@5.2.2)
+      '@typescript-eslint/type-utils': 5.59.6(eslint@8.54.0)(typescript@5.2.2)
+      '@typescript-eslint/utils': 5.59.6(eslint@8.54.0)(typescript@5.2.2)
       debug: 4.3.4
-      eslint: 8.51.0
+      eslint: 8.54.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
@@ -3272,20 +3368,20 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils@5.53.0(eslint@8.51.0)(typescript@5.2.2):
+  /@typescript-eslint/experimental-utils@5.53.0(eslint@8.54.0)(typescript@5.2.2):
     resolution: {integrity: sha512-4SklZEwRn0jqkhtW+pPZpbKFXprwGneBndRM0TGzJu/LWdb9QV2hBgFIVU9AREo02BzqFvyG/ypd+xAW5YGhXw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.53.0(eslint@8.51.0)(typescript@5.2.2)
-      eslint: 8.51.0
+      '@typescript-eslint/utils': 5.53.0(eslint@8.54.0)(typescript@5.2.2)
+      eslint: 8.54.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@typescript-eslint/parser@5.59.6(eslint@8.51.0)(typescript@5.2.2):
+  /@typescript-eslint/parser@5.59.6(eslint@8.54.0)(typescript@5.2.2):
     resolution: {integrity: sha512-7pCa6al03Pv1yf/dUg/s1pXz/yGMUBAw5EeWqNTFiSueKvRNonze3hma3lhdsOrQcaOXhbk5gKu2Fludiho9VA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3299,7 +3395,7 @@ packages:
       '@typescript-eslint/types': 5.59.6
       '@typescript-eslint/typescript-estree': 5.59.6(typescript@5.2.2)
       debug: 4.3.4
-      eslint: 8.51.0
+      eslint: 8.54.0
       typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
@@ -3321,7 +3417,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.59.6
     dev: true
 
-  /@typescript-eslint/type-utils@5.59.6(eslint@8.51.0)(typescript@5.2.2):
+  /@typescript-eslint/type-utils@5.59.6(eslint@8.54.0)(typescript@5.2.2):
     resolution: {integrity: sha512-A4tms2Mp5yNvLDlySF+kAThV9VTBPCvGf0Rp8nl/eoDX9Okun8byTKoj3fJ52IJitjWOk0fKPNQhXEB++eNozQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3332,9 +3428,9 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/typescript-estree': 5.59.6(typescript@5.2.2)
-      '@typescript-eslint/utils': 5.59.6(eslint@8.51.0)(typescript@5.2.2)
+      '@typescript-eslint/utils': 5.59.6(eslint@8.54.0)(typescript@5.2.2)
       debug: 4.3.4
-      eslint: 8.51.0
+      eslint: 8.54.0
       tsutils: 3.21.0(typescript@5.2.2)
       typescript: 5.2.2
     transitivePeerDependencies:
@@ -3393,7 +3489,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.53.0(eslint@8.51.0)(typescript@5.2.2):
+  /@typescript-eslint/utils@5.53.0(eslint@8.54.0)(typescript@5.2.2):
     resolution: {integrity: sha512-VUOOtPv27UNWLxFwQK/8+7kvxVC+hPHNsJjzlJyotlaHjLSIgOCKj9I0DBUjwOOA64qjBwx5afAPjksqOxMO0g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3404,28 +3500,28 @@ packages:
       '@typescript-eslint/scope-manager': 5.53.0
       '@typescript-eslint/types': 5.53.0
       '@typescript-eslint/typescript-estree': 5.53.0(typescript@5.2.2)
-      eslint: 8.51.0
+      eslint: 8.54.0
       eslint-scope: 5.1.1
-      eslint-utils: 3.0.0(eslint@8.51.0)
+      eslint-utils: 3.0.0(eslint@8.54.0)
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@typescript-eslint/utils@5.59.6(eslint@8.51.0)(typescript@5.2.2):
+  /@typescript-eslint/utils@5.59.6(eslint@8.54.0)(typescript@5.2.2):
     resolution: {integrity: sha512-vzaaD6EXbTS29cVH0JjXBdzMt6VBlv+hE31XktDRMX1j3462wZCJa7VzO2AxXEXcIl8GQqZPcOPuW/Z1tZVogg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.51.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.54.0)
       '@types/json-schema': 7.0.11
       '@types/semver': 7.3.13
       '@typescript-eslint/scope-manager': 5.59.6
       '@typescript-eslint/types': 5.59.6
       '@typescript-eslint/typescript-estree': 5.59.6(typescript@5.2.2)
-      eslint: 8.51.0
+      eslint: 8.54.0
       eslint-scope: 5.1.1
       semver: 7.5.4
     transitivePeerDependencies:
@@ -3447,6 +3543,10 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.59.6
       eslint-visitor-keys: 3.4.1
+    dev: true
+
+  /@ungap/structured-clone@1.2.0:
+    resolution: {integrity: sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==}
     dev: true
 
   /@vitest/expect@0.34.6:
@@ -4047,6 +4147,7 @@ packages:
 
   /buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+    requiresBuild: true
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
@@ -4295,11 +4396,6 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /cli-spinners@2.7.0:
-    resolution: {integrity: sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==}
-    engines: {node: '>=6'}
-    dev: true
-
   /cli-spinners@2.9.1:
     resolution: {integrity: sha512-jHgecW0pxkonBJdrKsqxgRX9AcG+u/5k0Q7WPDfi8AogLAdwxEkyYYNWwZ5GvVFoFx2uiY1eNcSK00fh+1+FyQ==}
     engines: {node: '>=6'}
@@ -4508,9 +4604,9 @@ packages:
     resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
     dev: true
 
-  /conventional-changelog-angular@6.0.0:
-    resolution: {integrity: sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==}
-    engines: {node: '>=14'}
+  /conventional-changelog-angular@7.0.0:
+    resolution: {integrity: sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==}
+    engines: {node: '>=16'}
     dependencies:
       compare-func: 2.0.0
     dev: true
@@ -4934,6 +5030,7 @@ packages:
 
   /end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
+    requiresBuild: true
     dependencies:
       once: 1.4.0
 
@@ -5167,7 +5264,7 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
-  /eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.27.5)(eslint@8.51.0):
+  /eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.27.5)(eslint@8.54.0):
     resolution: {integrity: sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -5175,14 +5272,14 @@ packages:
       eslint-plugin-import: ^2.25.2
     dependencies:
       confusing-browser-globals: 1.0.11
-      eslint: 8.51.0
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.51.0)
+      eslint: 8.54.0
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.54.0)
       object.assign: 4.1.4
       object.entries: 1.1.6
       semver: 6.3.0
     dev: true
 
-  /eslint-config-airbnb@19.0.4(eslint-plugin-import@2.27.5)(eslint-plugin-jsx-a11y@6.7.1)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.32.2)(eslint@8.51.0):
+  /eslint-config-airbnb@19.0.4(eslint-plugin-import@2.27.5)(eslint-plugin-jsx-a11y@6.7.1)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.32.2)(eslint@8.54.0):
     resolution: {integrity: sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==}
     engines: {node: ^10.12.0 || ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5192,36 +5289,36 @@ packages:
       eslint-plugin-react: ^7.28.0
       eslint-plugin-react-hooks: ^4.3.0
     dependencies:
-      eslint: 8.51.0
-      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.27.5)(eslint@8.51.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.51.0)
-      eslint-plugin-jsx-a11y: 6.7.1(eslint@8.51.0)
-      eslint-plugin-react: 7.32.2(eslint@8.51.0)
-      eslint-plugin-react-hooks: 4.6.0(eslint@8.51.0)
+      eslint: 8.54.0
+      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.27.5)(eslint@8.54.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.54.0)
+      eslint-plugin-jsx-a11y: 6.7.1(eslint@8.54.0)
+      eslint-plugin-react: 7.32.2(eslint@8.54.0)
+      eslint-plugin-react-hooks: 4.6.0(eslint@8.54.0)
       object.assign: 4.1.4
       object.entries: 1.1.6
     dev: true
 
-  /eslint-config-lxsmnsyc@0.6.5(eslint@8.51.0)(typescript@5.2.2):
+  /eslint-config-lxsmnsyc@0.6.5(eslint@8.54.0)(typescript@5.2.2):
     resolution: {integrity: sha512-0v4S5ZCDhw3nceG5yqSy2/eaWlogiARVTT6nMmmzu1H5HCqxbjRhvudKgNGeFw9LSFMmBRUUTr8P3K9e0GVNkQ==}
     peerDependencies:
       eslint: ^8.0
       typescript: ^4.0 || ^5.0
     dependencies:
       '@next/eslint-plugin-next': 13.4.2
-      '@typescript-eslint/eslint-plugin': 5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.51.0)(typescript@5.2.2)
-      '@typescript-eslint/parser': 5.59.6(eslint@8.51.0)(typescript@5.2.2)
-      eslint: 8.51.0
-      eslint-config-airbnb: 19.0.4(eslint-plugin-import@2.27.5)(eslint-plugin-jsx-a11y@6.7.1)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.32.2)(eslint@8.51.0)
-      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.27.5)(eslint@8.51.0)
-      eslint-config-preact: 1.3.0(@typescript-eslint/eslint-plugin@5.59.6)(eslint@8.51.0)(typescript@5.2.2)
+      '@typescript-eslint/eslint-plugin': 5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.54.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 5.59.6(eslint@8.54.0)(typescript@5.2.2)
+      eslint: 8.54.0
+      eslint-config-airbnb: 19.0.4(eslint-plugin-import@2.27.5)(eslint-plugin-jsx-a11y@6.7.1)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.32.2)(eslint@8.54.0)
+      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.27.5)(eslint@8.54.0)
+      eslint-config-preact: 1.3.0(@typescript-eslint/eslint-plugin@5.59.6)(eslint@8.54.0)(typescript@5.2.2)
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.51.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.51.0)
-      eslint-plugin-jsx-a11y: 6.7.1(eslint@8.51.0)
-      eslint-plugin-react: 7.32.2(eslint@8.51.0)
-      eslint-plugin-react-hooks: 4.6.0(eslint@8.51.0)
-      eslint-plugin-vue: 9.13.0(eslint@8.51.0)
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.54.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.54.0)
+      eslint-plugin-jsx-a11y: 6.7.1(eslint@8.54.0)
+      eslint-plugin-react: 7.32.2(eslint@8.54.0)
+      eslint-plugin-react-hooks: 4.6.0(eslint@8.54.0)
+      eslint-plugin-vue: 9.13.0(eslint@8.54.0)
       typescript: 5.2.2
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
@@ -5229,21 +5326,21 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-config-preact@1.3.0(@typescript-eslint/eslint-plugin@5.59.6)(eslint@8.51.0)(typescript@5.2.2):
+  /eslint-config-preact@1.3.0(@typescript-eslint/eslint-plugin@5.59.6)(eslint@8.54.0)(typescript@5.2.2):
     resolution: {integrity: sha512-yHYXg5qNzEJd3D/30AmsIW0W8MuY858KpApXp7xxBF08IYUljSKCOqMx+dVucXHQnAm7+11wOnMkgVHIBAechw==}
     peerDependencies:
       eslint: 6.x || 7.x || 8.x
     dependencies:
       '@babel/core': 7.23.2
-      '@babel/eslint-parser': 7.19.1(@babel/core@7.23.2)(eslint@8.51.0)
+      '@babel/eslint-parser': 7.19.1(@babel/core@7.23.2)(eslint@8.54.0)
       '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.23.2)
       '@babel/plugin-syntax-decorators': 7.21.0(@babel/core@7.23.2)
       '@babel/plugin-syntax-jsx': 7.21.4(@babel/core@7.23.2)
-      eslint: 8.51.0
-      eslint-plugin-compat: 4.1.2(eslint@8.51.0)
-      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.59.6)(eslint@8.51.0)(typescript@5.2.2)
-      eslint-plugin-react: 7.32.2(eslint@8.51.0)
-      eslint-plugin-react-hooks: 4.6.0(eslint@8.51.0)
+      eslint: 8.54.0
+      eslint-plugin-compat: 4.1.2(eslint@8.54.0)
+      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.59.6)(eslint@8.54.0)(typescript@5.2.2)
+      eslint-plugin-react: 7.32.2(eslint@8.54.0)
+      eslint-plugin-react-hooks: 4.6.0(eslint@8.54.0)
     transitivePeerDependencies:
       - '@typescript-eslint/eslint-plugin'
       - jest
@@ -5261,7 +5358,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.51.0):
+  /eslint-import-resolver-typescript@3.5.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.54.0):
     resolution: {integrity: sha512-TdJqPHs2lW5J9Zpe17DZNQuDnox4xo2o+0tE7Pggain9Rbc19ik8kFtXdxZ250FVx2kF4vlt2RSf4qlUpG7bhw==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -5270,9 +5367,9 @@ packages:
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.12.0
-      eslint: 8.51.0
-      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.51.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.51.0)
+      eslint: 8.54.0
+      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.54.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.54.0)
       get-tsconfig: 4.5.0
       globby: 13.1.3
       is-core-module: 2.11.0
@@ -5285,7 +5382,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.51.0):
+  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.54.0):
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -5306,16 +5403,16 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.59.6(eslint@8.51.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 5.59.6(eslint@8.54.0)(typescript@5.2.2)
       debug: 3.2.7
-      eslint: 8.51.0
+      eslint: 8.54.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.51.0)
+      eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.54.0)
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /eslint-plugin-compat@4.1.2(eslint@8.51.0):
+  /eslint-plugin-compat@4.1.2(eslint@8.54.0):
     resolution: {integrity: sha512-DNrQgDi5L4mAL4FdFboKBlSRg6MWfd75eA7K91lMjtP5ryN+O11qT2FDn7Z6zqy6sZ4sJawUR5V75qzB6l0CBg==}
     engines: {node: '>=16.x'}
     peerDependencies:
@@ -5325,13 +5422,13 @@ packages:
       ast-metadata-inferer: 0.7.0
       browserslist: 4.21.9
       caniuse-lite: 1.0.30001513
-      eslint: 8.51.0
+      eslint: 8.54.0
       find-up: 5.0.0
       lodash.memoize: 4.1.2
       semver: 7.3.8
     dev: true
 
-  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.51.0):
+  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.54.0):
     resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -5341,15 +5438,15 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.59.6(eslint@8.51.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 5.59.6(eslint@8.54.0)(typescript@5.2.2)
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 8.51.0
+      eslint: 8.54.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.51.0)
+      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.54.0)
       has: 1.0.3
       is-core-module: 2.11.0
       is-glob: 4.0.3
@@ -5364,7 +5461,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-jest@25.7.0(@typescript-eslint/eslint-plugin@5.59.6)(eslint@8.51.0)(typescript@5.2.2):
+  /eslint-plugin-jest@25.7.0(@typescript-eslint/eslint-plugin@5.59.6)(eslint@8.54.0)(typescript@5.2.2):
     resolution: {integrity: sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     peerDependencies:
@@ -5377,15 +5474,15 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.51.0)(typescript@5.2.2)
-      '@typescript-eslint/experimental-utils': 5.53.0(eslint@8.51.0)(typescript@5.2.2)
-      eslint: 8.51.0
+      '@typescript-eslint/eslint-plugin': 5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.54.0)(typescript@5.2.2)
+      '@typescript-eslint/experimental-utils': 5.53.0(eslint@8.54.0)(typescript@5.2.2)
+      eslint: 8.54.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /eslint-plugin-jsx-a11y@6.7.1(eslint@8.51.0):
+  /eslint-plugin-jsx-a11y@6.7.1(eslint@8.54.0):
     resolution: {integrity: sha512-63Bog4iIethyo8smBklORknVjB0T2dwB8Mr/hIC+fBS0uyHdYYpzM/Ed+YC8VxTjlXHEWFOdmgwcDn1U2L9VCA==}
     engines: {node: '>=4.0'}
     peerDependencies:
@@ -5400,7 +5497,7 @@ packages:
       axobject-query: 3.2.1
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 8.51.0
+      eslint: 8.54.0
       has: 1.0.3
       jsx-ast-utils: 3.3.3
       language-tags: 1.0.5
@@ -5410,16 +5507,16 @@ packages:
       semver: 6.3.0
     dev: true
 
-  /eslint-plugin-react-hooks@4.6.0(eslint@8.51.0):
+  /eslint-plugin-react-hooks@4.6.0(eslint@8.54.0):
     resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
     engines: {node: '>=10'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
     dependencies:
-      eslint: 8.51.0
+      eslint: 8.54.0
     dev: true
 
-  /eslint-plugin-react@7.32.2(eslint@8.51.0):
+  /eslint-plugin-react@7.32.2(eslint@8.54.0):
     resolution: {integrity: sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -5429,7 +5526,7 @@ packages:
       array.prototype.flatmap: 1.3.1
       array.prototype.tosorted: 1.1.1
       doctrine: 2.1.0
-      eslint: 8.51.0
+      eslint: 8.54.0
       estraverse: 5.3.0
       jsx-ast-utils: 3.3.3
       minimatch: 3.1.2
@@ -5443,19 +5540,19 @@ packages:
       string.prototype.matchall: 4.0.8
     dev: true
 
-  /eslint-plugin-vue@9.13.0(eslint@8.51.0):
+  /eslint-plugin-vue@9.13.0(eslint@8.54.0):
     resolution: {integrity: sha512-aBz9A8WB4wmpnVv0pYUt86cmH9EkcwWzgEwecBxMoRNhQjTL5i4sqadnwShv/hOdr8Hbl8XANGV7dtX9UQIAyA==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.2.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.51.0)
-      eslint: 8.51.0
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.54.0)
+      eslint: 8.54.0
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 6.0.11
       semver: 7.5.3
-      vue-eslint-parser: 9.3.0(eslint@8.51.0)
+      vue-eslint-parser: 9.3.0(eslint@8.54.0)
       xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -5485,13 +5582,13 @@ packages:
       estraverse: 5.3.0
     dev: true
 
-  /eslint-utils@3.0.0(eslint@8.51.0):
+  /eslint-utils@3.0.0(eslint@8.54.0):
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
     peerDependencies:
       eslint: '>=5'
     dependencies:
-      eslint: 8.51.0
+      eslint: 8.54.0
       eslint-visitor-keys: 2.1.0
     dev: true
 
@@ -5510,18 +5607,19 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /eslint@8.51.0:
-    resolution: {integrity: sha512-2WuxRZBrlwnXi+/vFSJyjMqrNjtJqiasMzehF0shoLaW7DzS3/9Yvrmq5JiT66+pNjiX4UBnLDiKHcWAr/OInA==}
+  /eslint@8.54.0:
+    resolution: {integrity: sha512-NY0DfAkM8BIZDVl6PgSa1ttZbx3xHgJzSNJKYcQglem6CppHyMhRIQkBVSSMaSRnLhig3jsDbEzOjwCVt4AmmA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.51.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.54.0)
       '@eslint-community/regexpp': 4.9.1
-      '@eslint/eslintrc': 2.1.2
-      '@eslint/js': 8.51.0
-      '@humanwhocodes/config-array': 0.11.11
+      '@eslint/eslintrc': 2.1.3
+      '@eslint/js': 8.54.0
+      '@humanwhocodes/config-array': 0.11.13
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
+      '@ungap/structured-clone': 1.2.0
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
@@ -5857,7 +5955,7 @@ packages:
     engines: {node: '>=14'}
     dependencies:
       cross-spawn: 7.0.3
-      signal-exit: 4.0.2
+      signal-exit: 4.1.0
     dev: true
 
   /form-data@4.0.0:
@@ -5879,6 +5977,7 @@ packages:
 
   /fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+    requiresBuild: true
 
   /fs-extra@11.1.1:
     resolution: {integrity: sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==}
@@ -5910,6 +6009,14 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
+    optional: true
+
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /function-bind@1.1.1:
@@ -7031,13 +7138,13 @@ packages:
       language-subtag-registry: 0.3.22
     dev: true
 
-  /lerna@7.3.0:
-    resolution: {integrity: sha512-Dt8TH+J+c9+3MhTYcm5OxnNzXb87WG7GPNj3kidjYJjJY7KxIMDNU37qBTYRWA1h3wAeNKBplXVQYUPkGcYgkQ==}
-    engines: {node: ^14.17.0 || >=16.0.0}
+  /lerna@7.4.2:
+    resolution: {integrity: sha512-gxavfzHfJ4JL30OvMunmlm4Anw7d7Tq6tdVHzUukLdS9nWnxCN/QB21qR+VJYp5tcyXogHKbdUEGh6qmeyzxSA==}
+    engines: {node: '>=16.0.0'}
     hasBin: true
     dependencies:
-      '@lerna/child-process': 7.3.0
-      '@lerna/create': 7.3.0
+      '@lerna/child-process': 7.4.2
+      '@lerna/create': 7.4.2
       '@npmcli/run-script': 6.0.2
       '@nx/devkit': 16.10.0(nx@16.10.0)
       '@octokit/plugin-enterprise-rest': 6.0.1
@@ -7047,7 +7154,7 @@ packages:
       clone-deep: 4.0.1
       cmd-shim: 6.0.1
       columnify: 1.6.0
-      conventional-changelog-angular: 6.0.0
+      conventional-changelog-angular: 7.0.0
       conventional-changelog-core: 5.0.1
       conventional-recommended-bump: 7.0.1
       cosmiconfig: 8.2.0
@@ -7095,7 +7202,7 @@ packages:
       read-package-json: 6.0.4
       resolve-from: 5.0.0
       rimraf: 4.4.1
-      semver: 7.5.3
+      semver: 7.5.4
       signal-exit: 3.0.7
       slash: 3.0.0
       ssri: 9.0.1
@@ -8165,7 +8272,7 @@ packages:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
     dependencies:
       hosted-git-info: 2.8.9
-      resolve: 1.22.2
+      resolve: 1.22.6
       semver: 5.7.1
       validate-npm-package-license: 3.0.4
     dev: true
@@ -8175,7 +8282,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       hosted-git-info: 4.1.0
-      is-core-module: 2.11.0
+      is-core-module: 2.13.0
       semver: 7.5.4
       validate-npm-package-license: 3.0.4
     dev: true
@@ -8185,7 +8292,7 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
       hosted-git-info: 6.1.1
-      is-core-module: 2.11.0
+      is-core-module: 2.13.0
       semver: 7.5.4
       validate-npm-package-license: 3.0.4
     dev: true
@@ -8364,7 +8471,7 @@ packages:
       tsconfig-paths: 4.1.2
       tslib: 2.6.2
       v8-compile-cache: 2.3.0
-      yargs: 17.7.1
+      yargs: 17.7.2
       yargs-parser: 21.1.1
     optionalDependencies:
       '@nx/nx-darwin-arm64': 16.10.0
@@ -8513,7 +8620,7 @@ packages:
       bl: 4.1.0
       chalk: 4.1.2
       cli-cursor: 3.1.0
-      cli-spinners: 2.7.0
+      cli-spinners: 2.9.1
       is-interactive: 1.0.0
       is-unicode-supported: 0.1.0
       log-symbols: 4.1.0
@@ -8974,7 +9081,7 @@ packages:
       react-is: 18.2.0
     dev: true
 
-  /pridepack@2.5.1(eslint@8.51.0)(tslib@2.6.2)(typescript@5.2.2):
+  /pridepack@2.5.1(eslint@8.54.0)(tslib@2.6.2)(typescript@5.2.2):
     resolution: {integrity: sha512-mDZ6VagGxqrf6ljjULRFWaw+VKhr15MulUXhfuH5blY2AfeXHd67iMtO4jsYOogB/eU6OGh5dGWzZMfbHBES2A==}
     engines: {node: '>=16'}
     hasBin: true
@@ -8987,7 +9094,7 @@ packages:
       degit: 2.8.4
       dotenv: 16.3.1
       esbuild: 0.19.4
-      eslint: 8.51.0
+      eslint: 8.54.0
       execa: 8.0.1
       license: 1.0.3
       ora: 7.0.1
@@ -9505,6 +9612,26 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
 
+  /rollup@4.5.0:
+    resolution: {integrity: sha512-41xsWhzxqjMDASCxH5ibw1mXk+3c4TNI2UjKbLxe6iEzrSQnqOzmmK8/3mufCPbzHNJ2e04Fc1ddI35hHy+8zg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.5.0
+      '@rollup/rollup-android-arm64': 4.5.0
+      '@rollup/rollup-darwin-arm64': 4.5.0
+      '@rollup/rollup-darwin-x64': 4.5.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.5.0
+      '@rollup/rollup-linux-arm64-gnu': 4.5.0
+      '@rollup/rollup-linux-arm64-musl': 4.5.0
+      '@rollup/rollup-linux-x64-gnu': 4.5.0
+      '@rollup/rollup-linux-x64-musl': 4.5.0
+      '@rollup/rollup-win32-arm64-msvc': 4.5.0
+      '@rollup/rollup-win32-ia32-msvc': 4.5.0
+      '@rollup/rollup-win32-x64-msvc': 4.5.0
+      fsevents: 2.3.3
+    dev: true
+
   /route-sort@1.0.0:
     resolution: {integrity: sha512-SFgmvjoIhp5S4iBEDW3XnbT+7PRuZ55oRuNjY+CDB1SGZkyCG9bqQ3/dhaZTctTBYMAvDxd2Uy9dStuaUfgJqQ==}
     engines: {node: '>= 6'}
@@ -9630,8 +9757,8 @@ packages:
       - supports-color
     dev: false
 
-  /seroval@0.12.0:
-    resolution: {integrity: sha512-5qvk9WRORhvOdHVtDv6KEKrTDbG8O9nODDdETfQcJ0u9iaZJ6mAASg/nQgPzqtuV9cqln9msE7WNmD+sJomrIw==}
+  /seroval@0.13.0:
+    resolution: {integrity: sha512-V1qVsFpYYwKn3sF6Tnq1JcbenFrUzyAxQNzMVkK7l5++adNzsaKxzOeufWbHXP0FLVyXzBcICE41Dy9K2sh5sA==}
     engines: {node: '>=10'}
     dev: false
 
@@ -9707,11 +9834,6 @@ packages:
 
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
-
-  /signal-exit@4.0.2:
-    resolution: {integrity: sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==}
-    engines: {node: '>=14'}
-    dev: true
 
   /signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
@@ -11060,6 +11182,42 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
 
+  /vite@5.0.0(@types/node@20.8.7):
+    resolution: {integrity: sha512-ESJVM59mdyGpsiNAeHQOR/0fqNoOyWPYesFto8FFZugfmhdHx8Fzd8sF3Q/xkVhZsyOxHfdM7ieiVAorI9RjFw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+    dependencies:
+      '@types/node': 20.8.7
+      esbuild: 0.19.4
+      postcss: 8.4.31
+      rollup: 4.5.0
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
   /vitefu@0.2.4(vite@4.4.11):
     resolution: {integrity: sha512-fanAXjSaf9xXtOOeno8wZXIhgia+CZury481LsDaV++lSvcU2R9Ch2bPh3PYFyoHW+w9LqAeYRISVQjUIew14g==}
     peerDependencies:
@@ -11141,14 +11299,14 @@ packages:
   /vscode-textmate@8.0.0:
     resolution: {integrity: sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==}
 
-  /vue-eslint-parser@9.3.0(eslint@8.51.0):
+  /vue-eslint-parser@9.3.0(eslint@8.54.0):
     resolution: {integrity: sha512-48IxT9d0+wArT1+3wNIy0tascRoywqSUe2E1YalIC1L8jsUGe5aJQItWfRok7DVFGz3UYvzEI7n5wiTXsCMAcQ==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: '>=6.0.0'
     dependencies:
       debug: 4.3.4
-      eslint: 8.51.0
+      eslint: 8.54.0
       eslint-scope: 7.2.0
       eslint-visitor-keys: 3.4.1
       espree: 9.6.0
@@ -11339,7 +11497,7 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
       imurmurhash: 0.1.4
-      signal-exit: 4.0.2
+      signal-exit: 4.1.0
     dev: true
 
   /write-json-file@3.2.0:
@@ -11442,19 +11600,6 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 20.2.4
-    dev: true
-
-  /yargs@17.7.1:
-    resolution: {integrity: sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==}
-    engines: {node: '>=12'}
-    dependencies:
-      cliui: 8.0.1
-      escalade: 3.1.1
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 21.1.1
     dev: true
 
   /yargs@17.7.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,13 +13,13 @@ importers:
         version: 8.54.0
       eslint-config-lxsmnsyc:
         specifier: ^0.6.5
-        version: 0.6.5(eslint@8.54.0)(typescript@5.2.2)
+        version: 0.6.5(eslint@8.54.0)(typescript@5.3.2)
       lerna:
         specifier: ^7.4.2
         version: 7.4.2
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^5.3.2
+        version: 5.3.2
 
   examples/astro:
     dependencies:
@@ -53,13 +53,13 @@ importers:
         version: 8.54.0
       eslint-config-lxsmnsyc:
         specifier: ^0.6.5
-        version: 0.6.5(eslint@8.54.0)(typescript@5.2.2)
+        version: 0.6.5(eslint@8.54.0)(typescript@5.3.2)
       postcss:
         specifier: ^8.4.31
         version: 8.4.31
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^5.3.2
+        version: 5.3.2
       unplugin-thaler:
         specifier: 0.7.2
         version: link:../../packages/unplugin
@@ -98,8 +98,8 @@ importers:
         specifier: ^0.3.6
         version: 0.3.6(solid-start@0.3.6)(vite@4.4.11)
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^5.3.2
+        version: 5.3.2
       unplugin-thaler:
         specifier: 0.7.2
         version: link:../../packages/unplugin
@@ -127,7 +127,7 @@ importers:
         version: 8.54.0
       eslint-config-lxsmnsyc:
         specifier: ^0.6.5
-        version: 0.6.5(eslint@8.54.0)(typescript@5.2.2)
+        version: 0.6.5(eslint@8.54.0)(typescript@5.3.2)
       svelte:
         specifier: ^4.0.5
         version: 4.0.5
@@ -138,8 +138,8 @@ importers:
         specifier: ^2.6.2
         version: 2.6.2
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^5.3.2
+        version: 5.3.2
       unplugin-thaler:
         specifier: 0.7.2
         version: link:../../packages/unplugin
@@ -162,8 +162,8 @@ importers:
         specifier: ^7.23.0
         version: 7.23.0
       seroval:
-        specifier: ^0.13.0
-        version: 0.13.0
+        specifier: ^0.13.2
+        version: 0.13.2
     devDependencies:
       '@types/babel__core':
         specifier: ^7.20.3
@@ -179,16 +179,16 @@ importers:
         version: 8.54.0
       eslint-config-lxsmnsyc:
         specifier: ^0.6.5
-        version: 0.6.5(eslint@8.54.0)(typescript@5.2.2)
+        version: 0.6.5(eslint@8.54.0)(typescript@5.3.2)
       pridepack:
         specifier: 2.5.1
-        version: 2.5.1(eslint@8.54.0)(tslib@2.6.2)(typescript@5.2.2)
+        version: 2.5.1(eslint@8.54.0)(tslib@2.6.2)(typescript@5.3.2)
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^5.3.2
+        version: 5.3.2
       vitest:
         specifier: ^0.34.6
         version: 0.34.6
@@ -210,10 +210,10 @@ importers:
         version: 8.54.0
       eslint-config-lxsmnsyc:
         specifier: ^0.6.5
-        version: 0.6.5(eslint@8.54.0)(typescript@5.2.2)
+        version: 0.6.5(eslint@8.54.0)(typescript@5.3.2)
       pridepack:
         specifier: 2.5.1
-        version: 2.5.1(eslint@8.54.0)(tslib@2.6.2)(typescript@5.2.2)
+        version: 2.5.1(eslint@8.54.0)(tslib@2.6.2)(typescript@5.3.2)
       thaler:
         specifier: 0.7.2
         version: link:../thaler
@@ -221,8 +221,8 @@ importers:
         specifier: ^2.6.2
         version: 2.6.2
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^5.3.2
+        version: 5.3.2
 
   packages/vite:
     dependencies:
@@ -238,16 +238,16 @@ importers:
         version: 8.54.0
       eslint-config-lxsmnsyc:
         specifier: ^0.6.5
-        version: 0.6.5(eslint@8.54.0)(typescript@5.2.2)
+        version: 0.6.5(eslint@8.54.0)(typescript@5.3.2)
       pridepack:
         specifier: 2.5.1
-        version: 2.5.1(eslint@8.54.0)(tslib@2.6.2)(typescript@5.2.2)
+        version: 2.5.1(eslint@8.54.0)(tslib@2.6.2)(typescript@5.3.2)
       tslib:
         specifier: ^2.6.2
         version: 2.6.2
       typescript:
-        specifier: ^5.2.2
-        version: 5.2.2
+        specifier: ^5.3.2
+        version: 5.3.2
       vite:
         specifier: ^5.0.0
         version: 5.0.0(@types/node@20.8.7)
@@ -3340,7 +3340,7 @@ packages:
   /@types/unist@3.0.0:
     resolution: {integrity: sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w==}
 
-  /@typescript-eslint/eslint-plugin@5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.54.0)(typescript@5.2.2):
+  /@typescript-eslint/eslint-plugin@5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.54.0)(typescript@5.3.2):
     resolution: {integrity: sha512-sXtOgJNEuRU5RLwPUb1jxtToZbgvq3M6FPpY4QENxoOggK+UpTxUBpj6tD8+Qh2g46Pi9We87E+eHnUw8YcGsw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3352,36 +3352,36 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.4.0
-      '@typescript-eslint/parser': 5.59.6(eslint@8.54.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 5.59.6(eslint@8.54.0)(typescript@5.3.2)
       '@typescript-eslint/scope-manager': 5.59.6
-      '@typescript-eslint/type-utils': 5.59.6(eslint@8.54.0)(typescript@5.2.2)
-      '@typescript-eslint/utils': 5.59.6(eslint@8.54.0)(typescript@5.2.2)
+      '@typescript-eslint/type-utils': 5.59.6(eslint@8.54.0)(typescript@5.3.2)
+      '@typescript-eslint/utils': 5.59.6(eslint@8.54.0)(typescript@5.3.2)
       debug: 4.3.4
       eslint: 8.54.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
       semver: 7.5.3
-      tsutils: 3.21.0(typescript@5.2.2)
-      typescript: 5.2.2
+      tsutils: 3.21.0(typescript@5.3.2)
+      typescript: 5.3.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils@5.53.0(eslint@8.54.0)(typescript@5.2.2):
+  /@typescript-eslint/experimental-utils@5.53.0(eslint@8.54.0)(typescript@5.3.2):
     resolution: {integrity: sha512-4SklZEwRn0jqkhtW+pPZpbKFXprwGneBndRM0TGzJu/LWdb9QV2hBgFIVU9AREo02BzqFvyG/ypd+xAW5YGhXw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.53.0(eslint@8.54.0)(typescript@5.2.2)
+      '@typescript-eslint/utils': 5.53.0(eslint@8.54.0)(typescript@5.3.2)
       eslint: 8.54.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@typescript-eslint/parser@5.59.6(eslint@8.54.0)(typescript@5.2.2):
+  /@typescript-eslint/parser@5.59.6(eslint@8.54.0)(typescript@5.3.2):
     resolution: {integrity: sha512-7pCa6al03Pv1yf/dUg/s1pXz/yGMUBAw5EeWqNTFiSueKvRNonze3hma3lhdsOrQcaOXhbk5gKu2Fludiho9VA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3393,10 +3393,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.59.6
       '@typescript-eslint/types': 5.59.6
-      '@typescript-eslint/typescript-estree': 5.59.6(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 5.59.6(typescript@5.3.2)
       debug: 4.3.4
       eslint: 8.54.0
-      typescript: 5.2.2
+      typescript: 5.3.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3417,7 +3417,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.59.6
     dev: true
 
-  /@typescript-eslint/type-utils@5.59.6(eslint@8.54.0)(typescript@5.2.2):
+  /@typescript-eslint/type-utils@5.59.6(eslint@8.54.0)(typescript@5.3.2):
     resolution: {integrity: sha512-A4tms2Mp5yNvLDlySF+kAThV9VTBPCvGf0Rp8nl/eoDX9Okun8byTKoj3fJ52IJitjWOk0fKPNQhXEB++eNozQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3427,12 +3427,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.59.6(typescript@5.2.2)
-      '@typescript-eslint/utils': 5.59.6(eslint@8.54.0)(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 5.59.6(typescript@5.3.2)
+      '@typescript-eslint/utils': 5.59.6(eslint@8.54.0)(typescript@5.3.2)
       debug: 4.3.4
       eslint: 8.54.0
-      tsutils: 3.21.0(typescript@5.2.2)
-      typescript: 5.2.2
+      tsutils: 3.21.0(typescript@5.3.2)
+      typescript: 5.3.2
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -3447,7 +3447,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.53.0(typescript@5.2.2):
+  /@typescript-eslint/typescript-estree@5.53.0(typescript@5.3.2):
     resolution: {integrity: sha512-eKmipH7QyScpHSkhbptBBYh9v8FxtngLquq292YTEQ1pxVs39yFBlLC1xeIZcPPz1RWGqb7YgERJRGkjw8ZV7w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3462,13 +3462,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.2.2)
-      typescript: 5.2.2
+      tsutils: 3.21.0(typescript@5.3.2)
+      typescript: 5.3.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.59.6(typescript@5.2.2):
+  /@typescript-eslint/typescript-estree@5.59.6(typescript@5.3.2):
     resolution: {integrity: sha512-vW6JP3lMAs/Tq4KjdI/RiHaaJSO7IUsbkz17it/Rl9Q+WkQ77EOuOnlbaU8kKfVIOJxMhnRiBG+olE7f3M16DA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3483,13 +3483,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.2.2)
-      typescript: 5.2.2
+      tsutils: 3.21.0(typescript@5.3.2)
+      typescript: 5.3.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.53.0(eslint@8.54.0)(typescript@5.2.2):
+  /@typescript-eslint/utils@5.53.0(eslint@8.54.0)(typescript@5.3.2):
     resolution: {integrity: sha512-VUOOtPv27UNWLxFwQK/8+7kvxVC+hPHNsJjzlJyotlaHjLSIgOCKj9I0DBUjwOOA64qjBwx5afAPjksqOxMO0g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3499,7 +3499,7 @@ packages:
       '@types/semver': 7.3.13
       '@typescript-eslint/scope-manager': 5.53.0
       '@typescript-eslint/types': 5.53.0
-      '@typescript-eslint/typescript-estree': 5.53.0(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 5.53.0(typescript@5.3.2)
       eslint: 8.54.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0(eslint@8.54.0)
@@ -3509,7 +3509,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/utils@5.59.6(eslint@8.54.0)(typescript@5.2.2):
+  /@typescript-eslint/utils@5.59.6(eslint@8.54.0)(typescript@5.3.2):
     resolution: {integrity: sha512-vzaaD6EXbTS29cVH0JjXBdzMt6VBlv+hE31XktDRMX1j3462wZCJa7VzO2AxXEXcIl8GQqZPcOPuW/Z1tZVogg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3520,7 +3520,7 @@ packages:
       '@types/semver': 7.3.13
       '@typescript-eslint/scope-manager': 5.59.6
       '@typescript-eslint/types': 5.59.6
-      '@typescript-eslint/typescript-estree': 5.59.6(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 5.59.6(typescript@5.3.2)
       eslint: 8.54.0
       eslint-scope: 5.1.1
       semver: 7.5.4
@@ -4353,7 +4353,7 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
 
   /chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
@@ -5299,19 +5299,19 @@ packages:
       object.entries: 1.1.6
     dev: true
 
-  /eslint-config-lxsmnsyc@0.6.5(eslint@8.54.0)(typescript@5.2.2):
+  /eslint-config-lxsmnsyc@0.6.5(eslint@8.54.0)(typescript@5.3.2):
     resolution: {integrity: sha512-0v4S5ZCDhw3nceG5yqSy2/eaWlogiARVTT6nMmmzu1H5HCqxbjRhvudKgNGeFw9LSFMmBRUUTr8P3K9e0GVNkQ==}
     peerDependencies:
       eslint: ^8.0
       typescript: ^4.0 || ^5.0
     dependencies:
       '@next/eslint-plugin-next': 13.4.2
-      '@typescript-eslint/eslint-plugin': 5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.54.0)(typescript@5.2.2)
-      '@typescript-eslint/parser': 5.59.6(eslint@8.54.0)(typescript@5.2.2)
+      '@typescript-eslint/eslint-plugin': 5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.54.0)(typescript@5.3.2)
+      '@typescript-eslint/parser': 5.59.6(eslint@8.54.0)(typescript@5.3.2)
       eslint: 8.54.0
       eslint-config-airbnb: 19.0.4(eslint-plugin-import@2.27.5)(eslint-plugin-jsx-a11y@6.7.1)(eslint-plugin-react-hooks@4.6.0)(eslint-plugin-react@7.32.2)(eslint@8.54.0)
       eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.27.5)(eslint@8.54.0)
-      eslint-config-preact: 1.3.0(@typescript-eslint/eslint-plugin@5.59.6)(eslint@8.54.0)(typescript@5.2.2)
+      eslint-config-preact: 1.3.0(@typescript-eslint/eslint-plugin@5.59.6)(eslint@8.54.0)(typescript@5.3.2)
       eslint-import-resolver-node: 0.3.7
       eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.54.0)
       eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.59.6)(eslint-import-resolver-typescript@3.5.5)(eslint@8.54.0)
@@ -5319,14 +5319,14 @@ packages:
       eslint-plugin-react: 7.32.2(eslint@8.54.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.54.0)
       eslint-plugin-vue: 9.13.0(eslint@8.54.0)
-      typescript: 5.2.2
+      typescript: 5.3.2
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - jest
       - supports-color
     dev: true
 
-  /eslint-config-preact@1.3.0(@typescript-eslint/eslint-plugin@5.59.6)(eslint@8.54.0)(typescript@5.2.2):
+  /eslint-config-preact@1.3.0(@typescript-eslint/eslint-plugin@5.59.6)(eslint@8.54.0)(typescript@5.3.2):
     resolution: {integrity: sha512-yHYXg5qNzEJd3D/30AmsIW0W8MuY858KpApXp7xxBF08IYUljSKCOqMx+dVucXHQnAm7+11wOnMkgVHIBAechw==}
     peerDependencies:
       eslint: 6.x || 7.x || 8.x
@@ -5338,7 +5338,7 @@ packages:
       '@babel/plugin-syntax-jsx': 7.21.4(@babel/core@7.23.2)
       eslint: 8.54.0
       eslint-plugin-compat: 4.1.2(eslint@8.54.0)
-      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.59.6)(eslint@8.54.0)(typescript@5.2.2)
+      eslint-plugin-jest: 25.7.0(@typescript-eslint/eslint-plugin@5.59.6)(eslint@8.54.0)(typescript@5.3.2)
       eslint-plugin-react: 7.32.2(eslint@8.54.0)
       eslint-plugin-react-hooks: 4.6.0(eslint@8.54.0)
     transitivePeerDependencies:
@@ -5403,7 +5403,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.59.6(eslint@8.54.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 5.59.6(eslint@8.54.0)(typescript@5.3.2)
       debug: 3.2.7
       eslint: 8.54.0
       eslint-import-resolver-node: 0.3.7
@@ -5438,7 +5438,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.59.6(eslint@8.54.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 5.59.6(eslint@8.54.0)(typescript@5.3.2)
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
@@ -5461,7 +5461,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-jest@25.7.0(@typescript-eslint/eslint-plugin@5.59.6)(eslint@8.54.0)(typescript@5.2.2):
+  /eslint-plugin-jest@25.7.0(@typescript-eslint/eslint-plugin@5.59.6)(eslint@8.54.0)(typescript@5.3.2):
     resolution: {integrity: sha512-PWLUEXeeF7C9QGKqvdSbzLOiLTx+bno7/HC9eefePfEb257QFHg7ye3dh80AZVkaa/RQsBB1Q/ORQvg2X7F0NQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     peerDependencies:
@@ -5474,8 +5474,8 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.54.0)(typescript@5.2.2)
-      '@typescript-eslint/experimental-utils': 5.53.0(eslint@8.54.0)(typescript@5.2.2)
+      '@typescript-eslint/eslint-plugin': 5.59.6(@typescript-eslint/parser@5.59.6)(eslint@8.54.0)(typescript@5.3.2)
+      '@typescript-eslint/experimental-utils': 5.53.0(eslint@8.54.0)(typescript@5.3.2)
       eslint: 8.54.0
     transitivePeerDependencies:
       - supports-color
@@ -6004,19 +6004,11 @@ packages:
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
-  /fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-    requiresBuild: true
-    optional: true
-
   /fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
-    dev: true
     optional: true
 
   /function-bind@1.1.1:
@@ -7209,7 +7201,7 @@ packages:
       strong-log-transformer: 2.1.0
       tar: 6.1.11
       temp-dir: 1.0.0
-      typescript: 5.2.2
+      typescript: 5.3.2
       upath: 2.0.1
       uuid: 9.0.0
       validate-npm-package-license: 3.0.4
@@ -9081,7 +9073,7 @@ packages:
       react-is: 18.2.0
     dev: true
 
-  /pridepack@2.5.1(eslint@8.54.0)(tslib@2.6.2)(typescript@5.2.2):
+  /pridepack@2.5.1(eslint@8.54.0)(tslib@2.6.2)(typescript@5.3.2):
     resolution: {integrity: sha512-mDZ6VagGxqrf6ljjULRFWaw+VKhr15MulUXhfuH5blY2AfeXHd67iMtO4jsYOogB/eU6OGh5dGWzZMfbHBES2A==}
     engines: {node: '>=16'}
     hasBin: true
@@ -9102,7 +9094,7 @@ packages:
       pretty-bytes: 6.1.1
       prompts: 2.4.2
       tslib: 2.6.2
-      typescript: 5.2.2
+      typescript: 5.3.2
       yargs: 17.7.2
     dev: true
 
@@ -9610,7 +9602,7 @@ packages:
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
 
   /rollup@4.5.0:
     resolution: {integrity: sha512-41xsWhzxqjMDASCxH5ibw1mXk+3c4TNI2UjKbLxe6iEzrSQnqOzmmK8/3mufCPbzHNJ2e04Fc1ddI35hHy+8zg==}
@@ -9757,8 +9749,8 @@ packages:
       - supports-color
     dev: false
 
-  /seroval@0.13.0:
-    resolution: {integrity: sha512-V1qVsFpYYwKn3sF6Tnq1JcbenFrUzyAxQNzMVkK7l5++adNzsaKxzOeufWbHXP0FLVyXzBcICE41Dy9K2sh5sA==}
+  /seroval@0.13.2:
+    resolution: {integrity: sha512-UgqszDJqNh+jgGGvLWLWOTMS3dwdEbJnGRXOixHFYE+e2s4pN5lwT77hZhB3ZJCfwXLhH1e0WN5UmpJeog2csA==}
     engines: {node: '>=10'}
     dev: false
 
@@ -10344,8 +10336,8 @@ packages:
       picocolors: 1.0.0
       sade: 1.8.1
       svelte: 4.0.5
-      svelte-preprocess: 5.0.4(@babel/core@7.23.2)(svelte@4.0.5)(typescript@5.2.2)
-      typescript: 5.2.2
+      svelte-preprocess: 5.0.4(@babel/core@7.23.2)(svelte@4.0.5)(typescript@5.3.2)
+      typescript: 5.3.2
     transitivePeerDependencies:
       - '@babel/core'
       - coffeescript
@@ -10367,7 +10359,7 @@ packages:
       svelte: 4.0.5
     dev: true
 
-  /svelte-preprocess@5.0.4(@babel/core@7.23.2)(svelte@4.0.5)(typescript@5.2.2):
+  /svelte-preprocess@5.0.4(@babel/core@7.23.2)(svelte@4.0.5)(typescript@5.3.2):
     resolution: {integrity: sha512-ABia2QegosxOGsVlsSBJvoWeXy1wUKSfF7SWJdTjLAbx/Y3SrVevvvbFNQqrSJw89+lNSsM58SipmZJ5SRi5iw==}
     engines: {node: '>= 14.10.0'}
     requiresBuild: true
@@ -10412,7 +10404,7 @@ packages:
       sorcery: 0.11.0
       strip-indent: 3.0.0
       svelte: 4.0.5
-      typescript: 5.2.2
+      typescript: 5.3.2
     dev: true
 
   /svelte@4.0.5:
@@ -10694,14 +10686,14 @@ packages:
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
-  /tsutils@3.21.0(typescript@5.2.2):
+  /tsutils@3.21.0(typescript@5.3.2):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.2.2
+      typescript: 5.3.2
     dev: true
 
   /tuf-js@1.1.7:
@@ -10790,8 +10782,8 @@ packages:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
     dev: true
 
-  /typescript@5.2.2:
-    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
+  /typescript@5.3.2:
+    resolution: {integrity: sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true
@@ -11180,7 +11172,7 @@ packages:
       postcss: 8.4.31
       rollup: 3.29.4
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
 
   /vite@5.0.0(@types/node@20.8.7):
     resolution: {integrity: sha512-ESJVM59mdyGpsiNAeHQOR/0fqNoOyWPYesFto8FFZugfmhdHx8Fzd8sF3Q/xkVhZsyOxHfdM7ieiVAorI9RjFw==}


### PR DESCRIPTION
Since seroval now has built-in support for AsyncIterables, and has JSON streaming API, we can now turn all seroval-based server functions to utilize the streaming feature.

Basically, this is now possible:

```js
const example = fn$(async function* foo(items: string[]) {
  for (const item of items) {
    yield sleep(item, 1000);
  }
});

// client code
const iterator = await example(['foo', 'bar', 'baz']);
for await (const value of iterator) {
  console.log('Received: ', value);
}
  ```